### PR TITLE
Added recursive substitution

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@ this is a simple proof assistant
 
 ## todo
 - [ ] add name recovery because now we just kinda drop them during the process of substitution, etc
+- [ ] add lazy evaluation
+- [ ] fix the bug where there are too much variables added to `ctx` in debruijn conversion. will be hard to fix

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,6 +8,19 @@ enum Expr {
     App(Box<Expr>, Box<Expr>),
 }
 
+impl Display for Expr {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Expr::Var(idx) => write!(f, "x_{}", idx),
+            Expr::Free(name) => write!(f, "{}", name),
+            Expr::Lam(body) => write!(f, "λ.{}", body),
+            Expr::App(lam, arg) => write!(f, "({}) {}", lam, arg),
+        }
+    }
+}
+
+/// Converts a named expression to a de Bruijn index expression.
+/// `ctx` is used to keep track of variable names in scope and their indices.
 fn to_debruijn(expr: &NamedExpr, ctx: &mut Vec<String>) -> Expr {
     match expr {
         NamedExpr::Var(name) => {
@@ -32,6 +45,10 @@ fn to_debruijn(expr: &NamedExpr, ctx: &mut Vec<String>) -> Expr {
     }
 }
 
+/// Converts a de Bruijn index expression back to a named expression.
+/// `ctx` is used to keep track of variable names in scope.
+/// Currently, the program does not keep track of the original names of variables,
+/// so it generates new names of the form `x_i` using the `fresh_var_name` function.
 fn from_debruijn(expr: &Expr, ctx: &mut Vec<String>) -> NamedExpr {
     match expr {
         Expr::Var(i) => {
@@ -84,7 +101,7 @@ fn fresh_var_name(ctx: &[String]) -> String {
 
 #[derive(Clone)]
 enum NamedExpr {
-    //Expr can be a Variabel, lambda function or Application
+    //Expr can be a Variable, lambda function or Application
     Var(String),
     Lam(String, Box<NamedExpr>),
     App(Box<NamedExpr>, Box<NamedExpr>),
@@ -121,6 +138,7 @@ impl Display for NamedExpr {
     }
 }
 
+/// Substitutes `var` with `value` in `root` a.k.a beta-reduction (`[var := value]root`).
 fn subst(root: &Expr, var: usize, value: &Expr) -> Expr {
     // [var := value]root
     match root {
@@ -142,15 +160,21 @@ fn subst(root: &Expr, var: usize, value: &Expr) -> Expr {
 
 fn eval(expr: Expr) -> Expr {
     match expr {
-        Expr::App(func, arg) => match *func {
-            Expr::Lam(body) => {
-                let arg_shifted = shift(&arg, 1, 0);
-                let res = subst(&body, 0, &arg_shifted);
-                shift(&res, -1, 0)
+        Expr::App(func, arg) => {
+            let func_evaled = eval(*func);
+            let arg_evaled = eval(*arg);
+
+            match func_evaled {
+                Expr::Lam(body) => {
+                    let arg_shifted = shift(&arg_evaled, 1, 0);
+                    let res = subst(&body, 0, &arg_shifted);
+                    eval(shift(&res, -1, 0))
+                }
+                // NOTE: wrong?
+                func_not_lam => Expr::App(Box::new(func_not_lam), Box::new(arg_evaled)),
             }
-            // NOTE: wrong?
-            func_not_lam => Expr::App(Box::new(func_not_lam), arg),
-        },
+        }
+        Expr::Lam(body) => Expr::Lam(Box::new(eval(*body))),
         _ => expr,
     }
 }
@@ -176,8 +200,75 @@ fn main() {
     eval_dbr(test);
 
     let t = lam("x", lam("y", var("x")));
-    let t_app = app(t.clone(), var("y"));
+    let t_app = app(app(t.clone(), var("y")), var("z"));
     eval_dbr(t_app);
 
     eval_dbr(var("x"));
+
+    let expr = app(
+        app(
+            lam("x", lam("y", app(var("x"), var("y")))),
+            lam("z", var("z")),
+        ),
+        var("a"),
+    );
+    eval_dbr(expr);
+
+    let expr = app(
+        lam("x", app(var("x"), lam("y", var("y")))),
+        lam("z", app(var("z"), var("z"))),
+    );
+    eval_dbr(expr);
+
+    let expr = app(
+        lam("x", app(lam("x", var("x")), app(var("x"), var("x")))),
+        lam("y", var("y")),
+    );
+    eval_dbr(expr);
+
+    let expr = app(
+        app(
+            lam(
+                "a",
+                lam("b", app(var("a"), lam("c", app(var("b"), var("c"))))),
+            ),
+            lam("x", app(var("x"), var("x"))),
+        ),
+        lam("y", var("y")),
+    );
+    eval_dbr(expr);
+
+    let expr = app(
+        app(
+            app(
+                lam(
+                    "f",
+                    lam(
+                        "g",
+                        lam("x", app(var("f"), app(var("g"), app(var("g"), var("x"))))),
+                    ),
+                ),
+                var("inc"), // imagine this is +1
+            ),
+            var("dbl"), // imagine this is *2
+        ),
+        var("z"),
+    );
+    eval_dbr(expr);
+
+    let expr = app(
+        app(
+            lam("x", lam("y", app(var("x"), app(var("y"), var("y"))))),
+            lam("a", lam("b", app(var("b"), var("a")))),
+        ),
+        lam("c", var("c")),
+    );
+    eval_dbr(expr);
+
+    // BUG: evaluates incorrectly
+    let expr = app(
+        lam("x", app(var("x"), var("x"))),
+        lam("y", lam("z", var("y"))),
+    );
+    eval_dbr(expr);
 }

--- a/src/main.rs
+++ b/src/main.rs
@@ -8,17 +8,6 @@ enum Expr {
     App(Box<Expr>, Box<Expr>),
 }
 
-impl Display for Expr {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Expr::Var(idx) => write!(f, "x_{}", idx),
-            Expr::Free(name) => write!(f, "{}", name),
-            Expr::Lam(body) => write!(f, "λ.{}", body),
-            Expr::App(lam, arg) => write!(f, "({}) {}", lam, arg),
-        }
-    }
-}
-
 /// Converts a named expression to a de Bruijn index expression.
 /// `ctx` is used to keep track of variable names in scope and their indices.
 fn to_debruijn(expr: &NamedExpr, ctx: &mut Vec<String>) -> Expr {


### PR DESCRIPTION
Expressions now reduce to their minimal form.
Also discovered a bug. When trying to evaluate `(λx. x x) (λy. λz. y)`, we get an incorrect result. The program apparently pushes one more variable which is incorrect. This is probably a scoping and context tracking issue. Will be hard to fix tbh