### PR TITLE
Added type inference through the Hinley-Milner type system

### DIFF
--- a/src/main.rs
+++ b/src/main.rs
@@ -8,7 +8,7 @@ use types::Type;
 
 use crate::{
     term::{lam, let_in},
-    types::infer,
+    types::{TypeEnv, TypeScheme, infer, infer_with_env},
 };
 
 fn main() {
@@ -18,9 +18,19 @@ fn main() {
     //    lam("g", lam("x", app(var("f"), app(var("g"), var("x"))))),
     //);
 
+    let mut prelude = TypeEnv::new();
+
+    // if you *know* a's type:
+    prelude.insert(
+        "a".into(),
+        TypeScheme {
+            forall: vec![],
+            body: Type::Base("Int".into()),
+        },
+    );
     let id = let_in("id", lam("x", var("x")), app(var("id"), var("a")));
 
-    match infer(&id) {
+    match infer_with_env(&id, &prelude) {
         Ok(ty) => println!("⊢ {} : {}", id, ty),
         Err(e) => println!("Error inferring type: {}", e),
     }

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,23 +6,20 @@ use std::collections::HashMap;
 use term::{app, typed_eval_dbr, typed_lam, var};
 use types::Type;
 
-use crate::types::infer;
+use crate::{term::lam, types::infer};
 
 fn main() {
-    let id = typed_lam(
-        "x",
-        var("x"),
-        Type::Arrow(
-            Box::new(Type::Base("α".into())),
-            Box::new(Type::Base("α".into())),
-        ),
+    //let id = lam("x", lam("y", lam("z", lam("w", var("w")))));
+    let id = lam(
+        "f",
+        lam("g", lam("x", app(var("f"), app(var("g"), var("x"))))),
     );
 
-    if let Ok(ty) = infer(&id) {
-        println!("Type of id: {}", ty);
-    } else {
-        println!("Failed to infer type of id");
+    match infer(&id) {
+        Ok(ty) => println!("⊢ {} : {}", id, ty),
+        Err(e) => println!("Error inferring type: {}", e),
     }
+
     let mut ctx: HashMap<String, Type> = HashMap::new();
     ctx.insert("y".into(), Type::Base("α".into()));
     ctx.insert("z".into(), Type::Base("α".into()));
@@ -41,17 +38,17 @@ fn main() {
     let _ = typed_eval_dbr(expr, &mut ctx);
     //println!("result: {}", result);
     //
-    //let test = "(λxasdasd.λy.x) yasdasd zz ";
-    //let mut lexer = parser::Lexer::new(test);
-    //println!(
-    //    "tok: {}",
-    //    lexer
-    //        .tokenize()
-    //        .iter()
-    //        .map(|t| t.token_kind.clone().to_string())
-    //        .collect::<Vec<_>>()
-    //        .join(" ")
-    //);
+    let test = "(λxasdasd.λy.x) yasdasd zz ";
+    let mut lexer = parser::Lexer::new(test);
+    println!(
+        "tok: {}",
+        lexer
+            .tokenize()
+            .iter()
+            .map(|t| t.token_kind.clone().to_string())
+            .collect::<Vec<_>>()
+            .join(" ")
+    );
 }
 
 #[cfg(test)]

--- a/src/main.rs
+++ b/src/main.rs
@@ -1,5 +1,6 @@
 mod parser;
 mod term;
+mod types;
 
 use std::collections::HashMap;
 use term::{Type, app, typed_eval_dbr, typed_lam, var};

--- a/src/main.rs
+++ b/src/main.rs
@@ -3,9 +3,26 @@ mod term;
 mod types;
 
 use std::collections::HashMap;
-use term::{Type, app, typed_eval_dbr, typed_lam, var};
+use term::{app, typed_eval_dbr, typed_lam, var};
+use types::Type;
+
+use crate::types::infer;
 
 fn main() {
+    let id = typed_lam(
+        "x",
+        var("x"),
+        Type::Arrow(
+            Box::new(Type::Base("α".into())),
+            Box::new(Type::Base("α".into())),
+        ),
+    );
+
+    if let Ok(ty) = infer(&id) {
+        println!("Type of id: {}", ty);
+    } else {
+        println!("Failed to infer type of id");
+    }
     let mut ctx: HashMap<String, Type> = HashMap::new();
     ctx.insert("y".into(), Type::Base("α".into()));
     ctx.insert("z".into(), Type::Base("α".into()));

--- a/src/main.rs
+++ b/src/main.rs
@@ -22,13 +22,13 @@ fn main() {
 
     // if you *know* a's type:
     prelude.insert(
-        "a".into(),
+        "true".into(),
         TypeScheme {
             forall: vec![],
-            body: Type::Base("Int".into()),
+            body: Type::Base("Bool".into()),
         },
     );
-    let id = let_in("id", lam("x", var("x")), app(var("id"), var("a")));
+    let id = let_in("id", lam("x", var("x")), app(var("id"), var("true")));
 
     match infer_with_env(&id, &prelude) {
         Ok(ty) => println!("⊢ {} : {}", id, ty),

--- a/src/main.rs
+++ b/src/main.rs
@@ -6,14 +6,19 @@ use std::collections::HashMap;
 use term::{app, typed_eval_dbr, typed_lam, var};
 use types::Type;
 
-use crate::{term::lam, types::infer};
+use crate::{
+    term::{lam, let_in},
+    types::infer,
+};
 
 fn main() {
     //let id = lam("x", lam("y", lam("z", lam("w", var("w")))));
-    let id = lam(
-        "f",
-        lam("g", lam("x", app(var("f"), app(var("g"), var("x"))))),
-    );
+    //let id = lam(
+    //    "f",
+    //    lam("g", lam("x", app(var("f"), app(var("g"), var("x"))))),
+    //);
+
+    let id = let_in("id", lam("x", var("x")), app(var("id"), var("a")));
 
     match infer(&id) {
         Ok(ty) => println!("⊢ {} : {}", id, ty),

--- a/src/term.rs
+++ b/src/term.rs
@@ -96,7 +96,7 @@ impl Display for Term {
         match self {
             Term::Free(name) => write!(f, "{}", name),
             Term::Bound(index) => write!(f, "#{}", index),
-            Term::Lam { name, ty, body } => write!(f, "λ{}:{}.{}", name, ty, body),
+            Term::Lam { name, ty, body } => write!(f, "λ{}.{}", name, body),
             Term::App { func, arg } => {
                 match func.as_ref() {
                     Term::Lam { .. } => write!(f, "({})", func),

--- a/src/term.rs
+++ b/src/term.rs
@@ -90,7 +90,7 @@ pub fn type_of(term: &Term, ctx: &mut TypeCtx) -> Result<Type, TypeError> {
 
 #[derive(Clone, Debug, PartialEq)]
 pub enum Term {
-    Free(String), // Unbound  
+    Free(String), // Unbound
     Bound(usize), // Debruijn index
 
     Lam {

--- a/src/term.rs
+++ b/src/term.rs
@@ -1,22 +1,8 @@
+use crate::types::Type;
 use std::{
     collections::{HashMap, HashSet},
     fmt::Display,
 };
-
-#[derive(Debug, Clone, PartialEq)]
-pub enum Type {
-    Base(String),                // atomic type
-    Arrow(Box<Type>, Box<Type>), // T1 -> T2
-}
-
-impl Display for Type {
-    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
-        match self {
-            Type::Base(name) => write!(f, "{}", name),
-            Type::Arrow(t1, t2) => write!(f, "({} -> {})", t1, t2),
-        }
-    }
-}
 
 type Ctx = Vec<String>; // Context of variable names
 pub type TypeCtx = HashMap<String, Type>; // Context of variable types

--- a/src/tests/beta.rs
+++ b/src/tests/beta.rs
@@ -214,10 +214,10 @@ fn test_application_inside_abstraction() {
     assert_eq!(result, expected);
 }
 #[test]
-fn test_identity_app(){
+fn test_identity_app() {
     // (λx. x) (λy. y) → λy. y
-    let identity = lam("x",var("x"));
-    let argument = lam("y",var("y"));
+    let identity = lam("x", var("x"));
+    let argument = lam("y", var("y"));
     let expr = app(identity, argument);
     let result = eval_dbr(expr);
     let expected = lam("y", var("y"));

--- a/src/tests/typed_beta.rs
+++ b/src/tests/typed_beta.rs
@@ -1,6 +1,7 @@
 use std::collections::HashMap;
 
-use crate::term::{Type, TypeCtx, app, typed_eval_dbr, typed_lam, var};
+use crate::term::{TypeCtx, app, typed_eval_dbr, typed_lam, var};
+use crate::types::Type;
 use pretty_assertions::assert_eq;
 
 fn any() -> Type {

--- a/src/types.rs
+++ b/src/types.rs
@@ -55,9 +55,9 @@ impl Display for TypeVar {
 /// ∀ α . Type
 /// Represents a type scheme that can be instantiated with type variables.
 #[derive(Debug, Clone, PartialEq, Eq)]
-struct TypeScheme {
-    forall: Vec<TypeVar>,
-    body: Type,
+pub struct TypeScheme {
+    pub forall: Vec<TypeVar>,
+    pub body: Type,
 }
 
 impl TypeScheme {
@@ -70,7 +70,7 @@ impl TypeScheme {
     }
 }
 
-type TypeEnv = HashMap<String, TypeScheme>;
+pub type TypeEnv = HashMap<String, TypeScheme>;
 
 #[derive(Default, Clone)]
 struct TypeSubst(HashMap<TypeVar, Type>);
@@ -272,8 +272,18 @@ fn infer_term_type(
     }
 }
 
+/// Infers the type of a term in the Hindley-Milner type system.
+/// Used only on terms that have no free variables.
 pub fn infer(term: &Term) -> Result<Type, TypeError> {
     let mut fresh = Fresh::default();
     let (s, t) = infer_term_type(term, &TypeEnv::new(), &mut fresh)?;
+    Ok(s.apply(&t))
+}
+
+/// Infers the type of a term in the Hindley-Milner type system,
+/// taking into account a given type environment.
+pub fn infer_with_env(term: &Term, env: &TypeEnv) -> Result<Type, TypeError> {
+    let mut fresh = Fresh::default();
+    let (s, t) = infer_term_type(term, env, &mut fresh)?;
     Ok(s.apply(&t))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,2 +1,131 @@
-use crate::term::{Term, Type};
-use std::{collections::HashMap, error::Error};
+use crate::term::Term;
+use std::{collections::HashMap, fmt::Display};
+
+#[derive(Debug, Clone, Eq, PartialEq)]
+pub enum Type {
+    Var(TypeVar),                // type meta variable
+    Base(String),                // atomic type
+    Arrow(Box<Type>, Box<Type>), // T1 -> T2
+}
+
+impl Display for Type {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            Type::Var(tv) => write!(f, "{}", tv),
+            Type::Base(name) => write!(f, "{}", name),
+            Type::Arrow(t1, t2) => write!(f, "({} -> {})", t1, t2),
+        }
+    }
+}
+
+/// Tiny wrapper around a type variable index.
+#[derive(Default)]
+struct Fresh(usize);
+impl Fresh {
+    fn fresh(&mut self) -> TypeVar {
+        let v = self.0;
+        self.0 += 1;
+        TypeVar(v)
+    }
+}
+
+/// Placeholder for an unknown type.
+#[derive(Debug, Clone, PartialEq, Eq, Hash, Copy)]
+pub struct TypeVar(usize);
+
+impl Display for TypeVar {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        let mut n = self.0;
+        let mut res = String::new();
+        loop {
+            res.push((b'a' + (n % 26) as u8) as char);
+            n /= 26;
+            if n == 0 {
+                break;
+            }
+            n -= 1;
+        }
+        write!(f, "'{}", res)
+    }
+}
+
+/// ∀ α . Type
+/// Represents a type scheme that can be instantiated with type variables.
+#[derive(Debug, Clone, PartialEq, Eq)]
+struct TypeScheme {
+    forall: Vec<TypeVar>,
+    body: Type,
+}
+
+impl TypeScheme {
+    fn instantiate(&self, fresh: &mut Fresh) -> Type {
+        let mut subst = TypeSubst::default();
+        for &type_var in &self.forall {
+            subst.0.insert(type_var, Type::Var(fresh.fresh()));
+        }
+        subst.apply(&self.body)
+    }
+}
+
+type TypeEnv = HashMap<String, TypeScheme>;
+
+#[derive(Default, Clone)]
+struct TypeSubst(HashMap<TypeVar, Type>);
+
+impl TypeSubst {
+    fn apply(&self, ty: &Type) -> Type {
+        match ty {
+            Type::Var(tv) => self.0.get(tv).cloned().unwrap_or(Type::Var(*tv)),
+            Type::Base(_) => ty.clone(),
+            Type::Arrow(t1, t2) => Type::Arrow(Box::new(self.apply(t1)), Box::new(self.apply(t2))),
+        }
+    }
+}
+
+pub enum TypeError {
+    UnboundVariable(String),
+    UnificationFailed(Type, Type),
+}
+
+fn infer_term_type(
+    term: &Term,
+    env: &TypeEnv,
+    fresh: &mut Fresh,
+) -> Result<(TypeSubst, Type), TypeError> {
+    match term {
+        Term::Free(name) => {
+            let scheme = env
+                .get(name)
+                .ok_or(TypeError::UnboundVariable(name.clone()))?;
+            Ok((
+                TypeSubst::default(),      // No substitution needed for free variables
+                scheme.instantiate(fresh), // Return the body of the type scheme
+            ))
+        }
+        Term::Lam { name, body, .. } => {
+            let tv = Type::Var(fresh.fresh());
+            let mut new_env = env.clone();
+            new_env.insert(
+                name.clone(),
+                TypeScheme {
+                    forall: vec![],
+                    body: tv.clone(),
+                },
+            );
+
+            let (subst, body_type) = infer_term_type(body, &new_env, fresh)?;
+            Ok((
+                subst.clone(),
+                Type::Arrow(Box::new(subst.apply(&tv)), Box::new(body_type)),
+            ))
+        }
+        Term::App { func, arg } => todo!(),
+        Term::Bound(_) => unreachable!("Bound variables should not be present in a surface term."),
+    }
+}
+
+pub fn infer(term: &Term) -> Result<Type, TypeError> {
+    let mut fresh = Fresh::default();
+    let (s, t) = infer_term_type(term, &TypeEnv::new(), &mut fresh)?;
+    Ok(s.apply(&t)) // Placeholder for the actual type
+}

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,5 +1,8 @@
 use crate::term::Term;
-use std::{collections::HashMap, fmt::Display};
+use std::{
+    collections::{HashMap, HashSet},
+    fmt::Display,
+};
 
 #[derive(Debug, Clone, Eq, PartialEq)]
 pub enum Type {
@@ -73,6 +76,10 @@ type TypeEnv = HashMap<String, TypeScheme>;
 struct TypeSubst(HashMap<TypeVar, Type>);
 
 impl TypeSubst {
+    fn singleton(tv: TypeVar, ty: Type) -> Self {
+        Self([(tv, ty)].into())
+    }
+
     fn apply(&self, ty: &Type) -> Type {
         match ty {
             Type::Var(tv) => self.0.get(tv).cloned().unwrap_or(Type::Var(*tv)),
@@ -80,13 +87,96 @@ impl TypeSubst {
             Type::Arrow(t1, t2) => Type::Arrow(Box::new(self.apply(t1)), Box::new(self.apply(t2))),
         }
     }
+
+    fn apply_scheme(&self, scheme: &TypeScheme) -> TypeScheme {
+        let filtered = TypeSubst(
+            self.0
+                .iter()
+                .filter(|(tv, _)| !scheme.forall.contains(tv))
+                .map(|(k, v)| (*k, v.clone()))
+                .collect(),
+        );
+        TypeScheme {
+            forall: scheme.forall.clone(),
+            body: filtered.apply(&scheme.body),
+        }
+    }
+
+    fn apply_env(&self, env: &TypeEnv) -> TypeEnv {
+        env.iter()
+            .map(|(k, v)| (k.clone(), self.apply_scheme(v)))
+            .collect()
+    }
+
+    fn compose(self, other: TypeSubst) -> TypeSubst {
+        let mut out = TypeSubst(
+            self.0
+                .into_iter()
+                .map(|(k, v)| (k, other.apply(&v)))
+                .collect(),
+        );
+        out.0.extend(other.0);
+        out
+    }
 }
 
 pub enum TypeError {
     UnboundVariable(String),
-    UnificationFailed(Type, Type),
+    Mismatch(Type, Type),
 }
 
+impl Display for TypeError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        match self {
+            TypeError::UnboundVariable(name) => write!(f, "Unbound variable `{}`", name),
+            TypeError::Mismatch(t1, t2) => {
+                write!(f, "Type mismatch: expected `{}`, found `{}`", t1, t2)
+            }
+        }
+    }
+}
+
+fn free_type_vars(ty: &Type) -> HashSet<TypeVar> {
+    use Type::*;
+    match ty {
+        Var(tv) => [*tv].into(),
+        Base(_) => HashSet::new(),
+        Arrow(t1, t2) => {
+            let mut vars = free_type_vars(t1);
+            vars.extend(free_type_vars(t2));
+            vars
+        }
+    }
+}
+fn bind(var: TypeVar, ty: Type) -> Result<TypeSubst, TypeError> {
+    if ty == Type::Var(var) {
+        return Ok(TypeSubst::default());
+    } else if free_type_vars(&ty).contains(&var) {
+        // this would mean an infite type
+        Err(TypeError::Mismatch(Type::Var(var), ty))
+    } else {
+        Ok(TypeSubst::singleton(var, ty))
+    }
+}
+
+fn unify(t1: &Type, t2: &Type) -> Result<TypeSubst, TypeError> {
+    use Type::*;
+    match (t1, t2) {
+        (Var(tv1), Var(tv2)) if tv1 == tv2 => Ok(TypeSubst::default()),
+
+        (Var(tv), _) => bind(*tv, t2.clone()),
+        (_, Var(tv)) => bind(*tv, t1.clone()),
+
+        (Base(a), Base(b)) if a == b => Ok(TypeSubst::default()),
+
+        (Arrow(a1, b1), Arrow(a2, b2)) => {
+            let s1 = unify(a1, a2)?;
+            let s2 = unify(&s1.apply(b1), &s1.apply(b2))?;
+            Ok(s1.compose(s2))
+        }
+        _ => Err(TypeError::Mismatch(t1.clone(), t2.clone())),
+    }
+}
 fn infer_term_type(
     term: &Term,
     env: &TypeEnv,
@@ -98,8 +188,8 @@ fn infer_term_type(
                 .get(name)
                 .ok_or(TypeError::UnboundVariable(name.clone()))?;
             Ok((
-                TypeSubst::default(),      // No substitution needed for free variables
-                scheme.instantiate(fresh), // Return the body of the type scheme
+                TypeSubst::default(), // No substitution needed for free variables
+                scheme.instantiate(fresh),
             ))
         }
         Term::Lam { name, body, .. } => {
@@ -119,7 +209,21 @@ fn infer_term_type(
                 Type::Arrow(Box::new(subst.apply(&tv)), Box::new(body_type)),
             ))
         }
-        Term::App { func, arg } => todo!(),
+        Term::App { func, arg } => {
+            let (subst1, func_type) = infer_term_type(func, env, fresh)?;
+            let (subst2, arg_type) = infer_term_type(arg, &subst1.apply_env(env), fresh)?;
+            let type_var = Type::Var(fresh.fresh());
+            let subst3 = unify(
+                &subst2.apply(&func_type),
+                &Type::Arrow(Box::new(arg_type), Box::new(type_var.clone())),
+            )?;
+
+            let subst = subst1.compose(subst2).compose(subst3);
+            Ok((
+                subst.clone(),
+                subst.apply(&type_var), // Return the type of the application
+            ))
+        }
         Term::Bound(_) => unreachable!("Bound variables should not be present in a surface term."),
     }
 }
@@ -127,5 +231,5 @@ fn infer_term_type(
 pub fn infer(term: &Term) -> Result<Type, TypeError> {
     let mut fresh = Fresh::default();
     let (s, t) = infer_term_type(term, &TypeEnv::new(), &mut fresh)?;
-    Ok(s.apply(&t)) // Placeholder for the actual type
+    Ok(s.apply(&t))
 }

--- a/src/types.rs
+++ b/src/types.rs
@@ -1,0 +1,2 @@
+use crate::term::{Term, Type};
+use std::{collections::HashMap, error::Error};


### PR DESCRIPTION
This is a pretty substantial PR. We added type inference through the Hinley-Milner type system and the W algorithm. The program now can take any valid expression and infer its type.
The program will always try and infer the most general type possible, introducing "meta type variables" when needed. This allows for polymorphism. For example, passing in an expression like `\x.x` will result in a type `'a -> 'a`. Then through let-in bindings, the system will instantiate and "fill" the types, taking any constraints into consideration. For example, the expression `let id = \x.x in id true` will evaluate to `Bool`.
This PR allows us to test the program much more ergonomically. We now don't need to manually calculate and specify the type of each term when testing.